### PR TITLE
Sprint 15: AIP Sentiment Integration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/blackms/ExplainableEngine/internal/aip"
 	"github.com/blackms/ExplainableEngine/internal/api"
 	"github.com/blackms/ExplainableEngine/internal/engine"
 	"github.com/blackms/ExplainableEngine/internal/llm"
@@ -75,7 +76,18 @@ func main() {
 		log.Println("LLM service: template fallback (no ANTHROPIC_API_KEY)")
 	}
 
-	router := api.NewRouter(store, orch, api.WithLLMService(llmService))
+	// Initialize AIP client.
+	routerOpts := []api.RouterOption{api.WithLLMService(llmService)}
+	aipAPIKey := os.Getenv("AIP_API_KEY")
+	if aipAPIKey != "" {
+		aipClient := aip.NewClient(aipAPIKey)
+		routerOpts = append(routerOpts, api.WithAIPClient(aipClient))
+		log.Println("AIP integration: enabled")
+	} else {
+		log.Println("AIP integration: disabled (no AIP_API_KEY)")
+	}
+
+	router := api.NewRouter(store, orch, routerOpts...)
 
 	// Wrap router with CORS and structured logging middleware.
 	// Order: CORS (outermost) -> Logging -> router (innermost with recovery/requestID/timing).

--- a/dashboard/src/app/aip/[ticker]/page.tsx
+++ b/dashboard/src/app/aip/[ticker]/page.tsx
@@ -1,330 +1,109 @@
 'use client';
-
 import { use } from 'react';
 import Link from 'next/link';
-import {
-  ArrowUpRight,
-  ArrowDownRight,
-  ArrowRight,
-  AlertCircle,
-  RefreshCw,
-} from 'lucide-react';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { useAIPExplainTicker } from '@/lib/api/hooks';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BreakdownChart } from '@/components/explanation/BreakdownChart';
 import { DriverRanking } from '@/components/explanation/DriverRanking';
-import { ConfidencePanel } from '@/components/explanation/ConfidencePanel';
-import { useAIPExplainTicker } from '@/lib/api/hooks';
+import { ConfidenceGauge } from '@/components/explanation/ConfidenceGauge';
 
-function sentimentStyle(label: string) {
-  const lower = label.toLowerCase();
-  if (lower === 'bullish')
-    return {
-      text: 'text-emerald-600 dark:text-emerald-400',
-      badge: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
-    };
-  if (lower === 'bearish')
-    return {
-      text: 'text-rose-600 dark:text-rose-400',
-      badge: 'bg-rose-500/15 text-rose-700 dark:text-rose-300',
-    };
-  return {
-    text: 'text-muted-foreground',
-    badge: 'bg-muted text-muted-foreground',
-  };
-}
-
-function trendInfo(trend: number) {
-  if (trend > 0.01)
-    return {
-      icon: ArrowUpRight,
-      color: 'text-emerald-500',
-      label: 'rising',
-    };
-  if (trend < -0.01)
-    return {
-      icon: ArrowDownRight,
-      color: 'text-rose-500',
-      label: 'declining',
-    };
-  return { icon: ArrowRight, color: 'text-muted-foreground', label: 'flat' };
-}
-
-function formatSigned(value: number) {
-  return (value >= 0 ? '+' : '') + value.toFixed(3);
-}
-
-function TickerSkeleton() {
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Skeleton className="h-5 w-12" />
-        <Skeleton className="h-8 w-56" />
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card>
-          <CardContent className="pt-4 space-y-2">
-            <Skeleton className="h-10 w-28" />
-            <Skeleton className="h-6 w-20" />
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-5 w-28" />
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-4 w-full" />
-            ))}
-          </CardContent>
-        </Card>
-      </div>
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-5 w-48" />
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-3">
-              <Skeleton className="h-4 w-[120px]" />
-              <Skeleton
-                className="h-8 rounded-full"
-                style={{ width: `${80 - i * 20}%` }}
-              />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-5 w-28" />
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3">
-                <Skeleton className="h-6 w-6 rounded-full" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-2 w-full rounded-full" />
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-5 w-28" />
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <Skeleton className="h-12 w-full rounded-lg" />
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
-}
-
-export default function AIPTickerPage({
-  params,
-}: {
-  params: Promise<{ ticker: string }>;
-}) {
+export default function AIPTickerPage({ params }: { params: Promise<{ ticker: string }> }) {
   const { ticker } = use(params);
-  const tickerUpper = ticker.toUpperCase();
-  const { data, isLoading, error, refetch } = useAIPExplainTicker(tickerUpper);
+  const { data, isLoading, error } = useAIPExplainTicker(ticker);
 
   if (isLoading) {
-    return <TickerSkeleton />;
-  }
-
-  if (error) {
     return (
-      <div className="flex items-center justify-center min-h-[40vh]">
-        <div className="text-center space-y-3">
-          <AlertCircle className="mx-auto size-10 text-rose-500" />
-          <h2 className="text-lg font-semibold">
-            Could not fetch sentiment for {tickerUpper}
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : 'An unexpected error occurred.'}
-          </p>
-          <button
-            type="button"
-            onClick={() => refetch()}
-            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
-          >
-            <RefreshCw className="size-3.5" />
-            Retry
-          </button>
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Skeleton className="h-40" />
+          <Skeleton className="h-40" />
         </div>
+        <Skeleton className="h-60" />
       </div>
     );
   }
 
-  if (!data) {
+  if (error || !data) {
     return (
-      <div className="flex items-center justify-center min-h-[40vh]">
-        <p className="text-sm text-muted-foreground">
-          AIP integration requires an API key. Contact your administrator.
-        </p>
+      <div className="space-y-4">
+        <Link href="/aip" className="text-sm text-muted-foreground hover:text-foreground">&larr; Back to AIP</Link>
+        <Card>
+          <CardContent className="p-8 text-center">
+            <p className="text-lg font-medium">Could not load sentiment for {ticker}</p>
+            <p className="text-sm text-muted-foreground mt-1">The ticker may not be available or AIP is not configured.</p>
+          </CardContent>
+        </Card>
       </div>
     );
   }
 
-  const { aip_data, explanation } = data;
-  const style = sentimentStyle(aip_data.sentiment_label);
-  const trend = trendInfo(aip_data.trend);
-  const TrendIcon = trend.icon;
+  const { explanation, aip_data } = data;
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Link
-            href="/aip"
-            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            &larr; Back
-          </Link>
-          <h1 className="text-2xl font-bold">
-            {tickerUpper} Sentiment Analysis
-          </h1>
+          <Link href="/aip" className="text-sm text-muted-foreground hover:text-foreground">&larr; Back</Link>
+          <h1 className="text-2xl font-bold">{ticker} Sentiment Analysis</h1>
         </div>
-        {explanation?.id && (
-          <Link
-            href={`/explain/${explanation.id}`}
-            className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent transition-colors"
-          >
-            Full Explanation
-          </Link>
-        )}
+        <Link href={`/explain/${explanation.id}`}>
+          <Button variant="outline" size="sm">Full Explanation &rarr;</Button>
+        </Link>
       </div>
 
-      {/* Sentiment overview + AIP raw data */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* Sentiment overview card */}
         <Card>
-          <CardHeader>
-            <CardTitle>Sentiment</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            <div className={`text-4xl font-bold tabular-nums ${style.text}`}>
-              {formatSigned(aip_data.sentiment_7d)}
+          <CardHeader><CardTitle>Sentiment Score</CardTitle></CardHeader>
+          <CardContent>
+            <div className="text-4xl font-bold tabular-nums">
+              {aip_data.sentiment_7d >= 0 ? '+' : ''}{aip_data.sentiment_7d.toFixed(3)}
             </div>
-            <span
-              className={`inline-block rounded-full px-2.5 py-0.5 text-sm font-medium ${style.badge}`}
-            >
-              {aip_data.sentiment_label}
-            </span>
-            <div
-              className={`flex items-center gap-1 text-sm font-medium ${trend.color}`}
-            >
-              <TrendIcon className="size-4" />
-              {formatSigned(aip_data.trend)} ({trend.label})
+            <div className="mt-1 text-sm text-muted-foreground">{aip_data.sentiment_label || 'N/A'}</div>
+            <div className="mt-3">
+              <ConfidenceGauge confidence={explanation.confidence} size="sm" />
             </div>
-            <p className="text-xs text-muted-foreground">
-              Scaled score: {aip_data.sentiment_score_scaled}
-            </p>
           </CardContent>
         </Card>
 
-        {/* AIP raw data card */}
         <Card>
-          <CardHeader>
-            <CardTitle>AIP Raw Data</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <dl className="space-y-2 text-sm">
-              <div className="flex items-center justify-between">
-                <dt className="text-muted-foreground">7d Sentiment</dt>
-                <dd className="font-medium tabular-nums">
-                  {formatSigned(aip_data.sentiment_7d)}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between">
-                <dt className="text-muted-foreground">30d Sentiment</dt>
-                <dd className="font-medium tabular-nums">
-                  {formatSigned(aip_data.sentiment_30d)}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between">
-                <dt className="text-muted-foreground">Trend</dt>
-                <dd
-                  className={`flex items-center gap-1 font-medium tabular-nums ${trend.color}`}
-                >
-                  <TrendIcon className="size-3.5" />
-                  {formatSigned(aip_data.trend)} ({trend.label})
-                </dd>
-              </div>
-              <div className="flex items-center justify-between">
-                <dt className="text-muted-foreground">Articles (7d)</dt>
-                <dd className="font-medium tabular-nums">
-                  {aip_data.article_count_7d}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between">
-                <dt className="text-muted-foreground">Positive ratio</dt>
-                <dd className="font-medium tabular-nums">
-                  {(aip_data.positive_ratio * 100).toFixed(0)}%
-                </dd>
-              </div>
-            </dl>
+          <CardHeader><CardTitle>AIP Raw Data</CardTitle></CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex justify-between"><span className="text-muted-foreground">7-day sentiment</span><span className="font-mono">{aip_data.sentiment_7d.toFixed(3)}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">30-day sentiment</span><span className="font-mono">{aip_data.sentiment_30d.toFixed(3)}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Trend</span><span className={`font-mono ${aip_data.trend >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>{aip_data.trend >= 0 ? '+' : ''}{aip_data.trend.toFixed(3)}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Articles (7d)</span><span>{aip_data.article_count_7d}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Positive ratio</span><span>{(aip_data.positive_ratio * 100).toFixed(0)}%</span></div>
           </CardContent>
         </Card>
       </div>
 
-      {/* Explanation Breakdown */}
-      {explanation?.breakdown && explanation.breakdown.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Explanation Breakdown</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <BreakdownChart breakdown={explanation.breakdown} />
-          </CardContent>
-        </Card>
-      )}
+      <Card>
+        <CardHeader><CardTitle>Explanation Breakdown</CardTitle></CardHeader>
+        <CardContent>
+          <BreakdownChart breakdown={explanation.breakdown} />
+        </CardContent>
+      </Card>
 
-      {/* Drivers + Confidence */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {explanation?.top_drivers && explanation.top_drivers.length > 0 && (
-          <DriverRanking drivers={explanation.top_drivers} />
-        )}
-        {explanation?.confidence_detail && (
-          <ConfidencePanel
-            overall={explanation.confidence}
-            perNode={explanation.confidence_detail.per_node ?? {}}
-            missingImpact={explanation.missing_impact}
-          />
-        )}
-      </div>
-
-      {/* AI Analysis link */}
-      {explanation?.id && (
+        <DriverRanking drivers={explanation.top_drivers} />
         <Card>
-          <CardContent className="flex items-center justify-between p-4">
-            <div>
-              <p className="text-sm font-medium">AI Analysis</p>
-              <p className="text-xs text-muted-foreground">
-                Ask AI about this sentiment and get deeper insights.
-              </p>
-            </div>
-            <Link
-              href={`/explain/${explanation.id}`}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
-            >
-              Ask AI about this sentiment
-            </Link>
+          <CardHeader><CardTitle>Data Quality</CardTitle></CardHeader>
+          <CardContent>
+            {explanation.missing_impact > 0 ? (
+              <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-700 dark:bg-amber-950">
+                {(explanation.missing_impact * 100).toFixed(1)}% of input data is missing
+              </div>
+            ) : (
+              <div className="rounded-lg border border-emerald-300 bg-emerald-50 p-3 text-sm dark:border-emerald-700 dark:bg-emerald-950">
+                All data sources available
+              </div>
+            )}
           </CardContent>
         </Card>
-      )}
+      </div>
     </div>
   );
 }

--- a/dashboard/src/app/aip/[ticker]/page.tsx
+++ b/dashboard/src/app/aip/[ticker]/page.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { use } from 'react';
+import Link from 'next/link';
+import {
+  ArrowUpRight,
+  ArrowDownRight,
+  ArrowRight,
+  AlertCircle,
+  RefreshCw,
+} from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BreakdownChart } from '@/components/explanation/BreakdownChart';
+import { DriverRanking } from '@/components/explanation/DriverRanking';
+import { ConfidencePanel } from '@/components/explanation/ConfidencePanel';
+import { useAIPExplainTicker } from '@/lib/api/hooks';
+
+function sentimentStyle(label: string) {
+  const lower = label.toLowerCase();
+  if (lower === 'bullish')
+    return {
+      text: 'text-emerald-600 dark:text-emerald-400',
+      badge: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+    };
+  if (lower === 'bearish')
+    return {
+      text: 'text-rose-600 dark:text-rose-400',
+      badge: 'bg-rose-500/15 text-rose-700 dark:text-rose-300',
+    };
+  return {
+    text: 'text-muted-foreground',
+    badge: 'bg-muted text-muted-foreground',
+  };
+}
+
+function trendInfo(trend: number) {
+  if (trend > 0.01)
+    return {
+      icon: ArrowUpRight,
+      color: 'text-emerald-500',
+      label: 'rising',
+    };
+  if (trend < -0.01)
+    return {
+      icon: ArrowDownRight,
+      color: 'text-rose-500',
+      label: 'declining',
+    };
+  return { icon: ArrowRight, color: 'text-muted-foreground', label: 'flat' };
+}
+
+function formatSigned(value: number) {
+  return (value >= 0 ? '+' : '') + value.toFixed(3);
+}
+
+function TickerSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-5 w-12" />
+        <Skeleton className="h-8 w-56" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card>
+          <CardContent className="pt-4 space-y-2">
+            <Skeleton className="h-10 w-28" />
+            <Skeleton className="h-6 w-20" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-28" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton className="h-4 w-[120px]" />
+              <Skeleton
+                className="h-8 rounded-full"
+                style={{ width: `${80 - i * 20}%` }}
+              />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-28" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-6 w-6 rounded-full" />
+                <div className="flex-1 space-y-1">
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-2 w-full rounded-full" />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-28" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-12 w-full rounded-lg" />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default function AIPTickerPage({
+  params,
+}: {
+  params: Promise<{ ticker: string }>;
+}) {
+  const { ticker } = use(params);
+  const tickerUpper = ticker.toUpperCase();
+  const { data, isLoading, error, refetch } = useAIPExplainTicker(tickerUpper);
+
+  if (isLoading) {
+    return <TickerSkeleton />;
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh]">
+        <div className="text-center space-y-3">
+          <AlertCircle className="mx-auto size-10 text-rose-500" />
+          <h2 className="text-lg font-semibold">
+            Could not fetch sentiment for {tickerUpper}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : 'An unexpected error occurred.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+          >
+            <RefreshCw className="size-3.5" />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh]">
+        <p className="text-sm text-muted-foreground">
+          AIP integration requires an API key. Contact your administrator.
+        </p>
+      </div>
+    );
+  }
+
+  const { aip_data, explanation } = data;
+  const style = sentimentStyle(aip_data.sentiment_label);
+  const trend = trendInfo(aip_data.trend);
+  const TrendIcon = trend.icon;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/aip"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            &larr; Back
+          </Link>
+          <h1 className="text-2xl font-bold">
+            {tickerUpper} Sentiment Analysis
+          </h1>
+        </div>
+        {explanation?.id && (
+          <Link
+            href={`/explain/${explanation.id}`}
+            className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent transition-colors"
+          >
+            Full Explanation
+          </Link>
+        )}
+      </div>
+
+      {/* Sentiment overview + AIP raw data */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Sentiment overview card */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Sentiment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className={`text-4xl font-bold tabular-nums ${style.text}`}>
+              {formatSigned(aip_data.sentiment_7d)}
+            </div>
+            <span
+              className={`inline-block rounded-full px-2.5 py-0.5 text-sm font-medium ${style.badge}`}
+            >
+              {aip_data.sentiment_label}
+            </span>
+            <div
+              className={`flex items-center gap-1 text-sm font-medium ${trend.color}`}
+            >
+              <TrendIcon className="size-4" />
+              {formatSigned(aip_data.trend)} ({trend.label})
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Scaled score: {aip_data.sentiment_score_scaled}
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* AIP raw data card */}
+        <Card>
+          <CardHeader>
+            <CardTitle>AIP Raw Data</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">7d Sentiment</dt>
+                <dd className="font-medium tabular-nums">
+                  {formatSigned(aip_data.sentiment_7d)}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">30d Sentiment</dt>
+                <dd className="font-medium tabular-nums">
+                  {formatSigned(aip_data.sentiment_30d)}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Trend</dt>
+                <dd
+                  className={`flex items-center gap-1 font-medium tabular-nums ${trend.color}`}
+                >
+                  <TrendIcon className="size-3.5" />
+                  {formatSigned(aip_data.trend)} ({trend.label})
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Articles (7d)</dt>
+                <dd className="font-medium tabular-nums">
+                  {aip_data.article_count_7d}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Positive ratio</dt>
+                <dd className="font-medium tabular-nums">
+                  {(aip_data.positive_ratio * 100).toFixed(0)}%
+                </dd>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Explanation Breakdown */}
+      {explanation?.breakdown && explanation.breakdown.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Explanation Breakdown</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BreakdownChart breakdown={explanation.breakdown} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Drivers + Confidence */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {explanation?.top_drivers && explanation.top_drivers.length > 0 && (
+          <DriverRanking drivers={explanation.top_drivers} />
+        )}
+        {explanation?.confidence_detail && (
+          <ConfidencePanel
+            overall={explanation.confidence}
+            perNode={explanation.confidence_detail.per_node ?? {}}
+            missingImpact={explanation.missing_impact}
+          />
+        )}
+      </div>
+
+      {/* AI Analysis link */}
+      {explanation?.id && (
+        <Card>
+          <CardContent className="flex items-center justify-between p-4">
+            <div>
+              <p className="text-sm font-medium">AI Analysis</p>
+              <p className="text-xs text-muted-foreground">
+                Ask AI about this sentiment and get deeper insights.
+              </p>
+            </div>
+            <Link
+              href={`/explain/${explanation.id}`}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+            >
+              Ask AI about this sentiment
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/aip/page.tsx
+++ b/dashboard/src/app/aip/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  TrendingUp,
+  Search,
+  Newspaper,
+  ArrowUpRight,
+  ArrowDownRight,
+  ArrowRight,
+  AlertCircle,
+  RefreshCw,
+} from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useAIPMarketMood } from '@/lib/api/hooks';
+import Link from 'next/link';
+
+const POPULAR_TICKERS = ['AAPL', 'MSFT', 'NVDA', 'TSLA', 'AMZN', 'GOOGL', 'META', 'JPM'];
+
+function trendIndicator(trend: number) {
+  if (trend > 0.01)
+    return {
+      icon: ArrowUpRight,
+      color: 'text-emerald-500',
+      label: 'rising',
+    };
+  if (trend < -0.01)
+    return {
+      icon: ArrowDownRight,
+      color: 'text-rose-500',
+      label: 'declining',
+    };
+  return { icon: ArrowRight, color: 'text-muted-foreground', label: 'flat' };
+}
+
+function formatSentiment(value: number) {
+  return (value >= 0 ? '+' : '') + value.toFixed(3);
+}
+
+export default function AIPPage() {
+  const router = useRouter();
+  const [tickerInput, setTickerInput] = useState('');
+  const {
+    data: moodData,
+    isLoading: moodLoading,
+    error: moodError,
+    refetch: refetchMood,
+  } = useAIPMarketMood();
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const ticker = tickerInput.trim().toUpperCase();
+    if (ticker) {
+      router.push(`/aip/${ticker}`);
+    }
+  }
+
+  const mood = moodData?.market_mood;
+  const trend = mood ? trendIndicator(mood.overall_trend) : null;
+  const TrendIcon = trend?.icon ?? ArrowRight;
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <div className="flex items-center gap-2">
+          <TrendingUp className="size-6 text-primary" />
+          <h1 className="text-3xl font-bold tracking-tight">
+            AIP Sentiment Intelligence
+          </h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          AI-powered sentiment analysis for financial tickers, backed by
+          explainable breakdowns.
+        </p>
+      </div>
+
+      {/* Ticker search */}
+      <form onSubmit={handleSearch} className="flex items-center gap-2">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            value={tickerInput}
+            onChange={(e) => setTickerInput(e.target.value)}
+            placeholder="Search ticker (e.g. NVDA)"
+            className="h-10 w-full rounded-md border border-input bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          />
+        </div>
+        <button
+          type="submit"
+          className="inline-flex h-10 items-center gap-1.5 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+        >
+          Explain
+        </button>
+      </form>
+
+      {/* Market Mood */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Newspaper className="size-5" />
+            Market Mood
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {moodLoading ? (
+            <div className="space-y-3">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-28" />
+                <Skeleton className="h-6 w-36" />
+              </div>
+              <Skeleton className="h-5 w-40" />
+            </div>
+          ) : moodError ? (
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <AlertCircle className="size-5 text-rose-500 shrink-0" />
+              <p>Could not fetch market mood data.</p>
+              <button
+                type="button"
+                onClick={() => refetchMood()}
+                className="inline-flex items-center gap-1 text-primary hover:underline"
+              >
+                <RefreshCw className="size-3.5" />
+                Retry
+              </button>
+            </div>
+          ) : mood ? (
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-baseline gap-4">
+                <span className="text-2xl font-bold tabular-nums">
+                  Overall: {formatSentiment(mood.overall_sentiment)}
+                </span>
+                <span
+                  className={`flex items-center gap-1 text-sm font-medium ${trend?.color}`}
+                >
+                  <TrendIcon className="size-4" />
+                  Trend: {formatSentiment(mood.overall_trend)} ({trend?.label})
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {mood.total_articles.toLocaleString()} articles analyzed
+              </p>
+              {moodData?.explanation?.id && (
+                <Link
+                  href={`/explain/${moodData.explanation.id}`}
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  View Full Breakdown
+                  <ArrowRight className="size-3.5" />
+                </Link>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              AIP integration requires an API key. Contact your administrator.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Quick Explains */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">Quick Explains</h2>
+        <div className="flex flex-wrap gap-2">
+          {POPULAR_TICKERS.map((ticker) => (
+            <Link
+              key={ticker}
+              href={`/aip/${ticker}`}
+              className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              {ticker}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/aip/page.tsx
+++ b/dashboard/src/app/aip/page.tsx
@@ -1,183 +1,82 @@
 'use client';
-
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  TrendingUp,
-  Search,
-  Newspaper,
-  ArrowUpRight,
-  ArrowDownRight,
-  ArrowRight,
-  AlertCircle,
-  RefreshCw,
-} from 'lucide-react';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useAIPMarketMood } from '@/lib/api/hooks';
-import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
 
 const POPULAR_TICKERS = ['AAPL', 'MSFT', 'NVDA', 'TSLA', 'AMZN', 'GOOGL', 'META', 'JPM'];
 
-function trendIndicator(trend: number) {
-  if (trend > 0.01)
-    return {
-      icon: ArrowUpRight,
-      color: 'text-emerald-500',
-      label: 'rising',
-    };
-  if (trend < -0.01)
-    return {
-      icon: ArrowDownRight,
-      color: 'text-rose-500',
-      label: 'declining',
-    };
-  return { icon: ArrowRight, color: 'text-muted-foreground', label: 'flat' };
-}
-
-function formatSentiment(value: number) {
-  return (value >= 0 ? '+' : '') + value.toFixed(3);
-}
-
 export default function AIPPage() {
+  const [ticker, setTicker] = useState('');
   const router = useRouter();
-  const [tickerInput, setTickerInput] = useState('');
-  const {
-    data: moodData,
-    isLoading: moodLoading,
-    error: moodError,
-    refetch: refetchMood,
-  } = useAIPMarketMood();
+  const { data: mood, isLoading: moodLoading, error: moodError } = useAIPMarketMood();
 
-  function handleSearch(e: React.FormEvent) {
-    e.preventDefault();
-    const ticker = tickerInput.trim().toUpperCase();
-    if (ticker) {
-      router.push(`/aip/${ticker}`);
-    }
-  }
-
-  const mood = moodData?.market_mood;
-  const trend = mood ? trendIndicator(mood.overall_trend) : null;
-  const TrendIcon = trend?.icon ?? ArrowRight;
+  const handleExplain = () => {
+    if (ticker.trim()) router.push(`/aip/${ticker.trim().toUpperCase()}`);
+  };
 
   return (
     <div className="space-y-6">
-      {/* Page header */}
       <div>
-        <div className="flex items-center gap-2">
-          <TrendingUp className="size-6 text-primary" />
-          <h1 className="text-3xl font-bold tracking-tight">
-            AIP Sentiment Intelligence
-          </h1>
-        </div>
-        <p className="mt-1 text-sm text-muted-foreground">
-          AI-powered sentiment analysis for financial tickers, backed by
-          explainable breakdowns.
-        </p>
+        <h1 className="text-2xl font-bold">AIP Sentiment Intelligence</h1>
+        <p className="text-sm text-muted-foreground">Explain sentiment scores powered by AIP</p>
       </div>
 
-      {/* Ticker search */}
-      <form onSubmit={handleSearch} className="flex items-center gap-2">
-        <div className="relative flex-1 max-w-md">
-          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            type="text"
-            value={tickerInput}
-            onChange={(e) => setTickerInput(e.target.value)}
-            placeholder="Search ticker (e.g. NVDA)"
-            className="h-10 w-full rounded-md border border-input bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-          />
-        </div>
-        <button
-          type="submit"
-          className="inline-flex h-10 items-center gap-1.5 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
-        >
-          Explain
-        </button>
-      </form>
-
-      {/* Market Mood */}
       <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Newspaper className="size-5" />
-            Market Mood
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {moodLoading ? (
-            <div className="space-y-3">
-              <div className="flex items-center gap-4">
-                <Skeleton className="h-8 w-28" />
-                <Skeleton className="h-6 w-36" />
-              </div>
-              <Skeleton className="h-5 w-40" />
-            </div>
-          ) : moodError ? (
-            <div className="flex items-center gap-3 text-sm text-muted-foreground">
-              <AlertCircle className="size-5 text-rose-500 shrink-0" />
-              <p>Could not fetch market mood data.</p>
-              <button
-                type="button"
-                onClick={() => refetchMood()}
-                className="inline-flex items-center gap-1 text-primary hover:underline"
-              >
-                <RefreshCw className="size-3.5" />
-                Retry
-              </button>
-            </div>
-          ) : mood ? (
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-baseline gap-4">
-                <span className="text-2xl font-bold tabular-nums">
-                  Overall: {formatSentiment(mood.overall_sentiment)}
-                </span>
-                <span
-                  className={`flex items-center gap-1 text-sm font-medium ${trend?.color}`}
-                >
-                  <TrendIcon className="size-4" />
-                  Trend: {formatSentiment(mood.overall_trend)} ({trend?.label})
-                </span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                {mood.total_articles.toLocaleString()} articles analyzed
-              </p>
-              {moodData?.explanation?.id && (
-                <Link
-                  href={`/explain/${moodData.explanation.id}`}
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  View Full Breakdown
-                  <ArrowRight className="size-3.5" />
-                </Link>
-              )}
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              AIP integration requires an API key. Contact your administrator.
-            </p>
-          )}
+        <CardContent className="p-4">
+          <form onSubmit={(e) => { e.preventDefault(); handleExplain(); }} className="flex gap-2">
+            <Input
+              placeholder="Enter ticker (e.g. AAPL)"
+              value={ticker}
+              onChange={(e) => setTicker(e.target.value)}
+              className="max-w-xs uppercase"
+            />
+            <Button type="submit" disabled={!ticker.trim()}>Explain</Button>
+          </form>
         </CardContent>
       </Card>
 
-      {/* Quick Explains */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Market Mood</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {moodLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-6 w-48" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ) : moodError ? (
+            <p className="text-sm text-muted-foreground">Could not load market mood. AIP may not be configured.</p>
+          ) : mood ? (
+            <div className="space-y-2">
+              <div className="flex items-baseline gap-3">
+                <span className="text-3xl font-bold tabular-nums">
+                  {mood.market_mood.overall_sentiment >= 0 ? '+' : ''}{mood.market_mood.overall_sentiment.toFixed(3)}
+                </span>
+                <span className={`text-sm ${mood.market_mood.overall_trend >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
+                  {mood.market_mood.overall_trend >= 0 ? '\u2191' : '\u2193'} {mood.market_mood.overall_trend.toFixed(3)}
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground">{mood.market_mood.total_articles.toLocaleString()} articles analyzed</p>
+              <Button variant="outline" size="sm" onClick={() => router.push(`/explain/${mood.explanation.id}`)}>
+                View Full Breakdown
+              </Button>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
       <div>
-        <h2 className="mb-3 text-lg font-semibold">Quick Explains</h2>
+        <h2 className="text-lg font-semibold mb-3">Quick Explain</h2>
         <div className="flex flex-wrap gap-2">
-          {POPULAR_TICKERS.map((ticker) => (
-            <Link
-              key={ticker}
-              href={`/aip/${ticker}`}
-              className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground"
-            >
-              {ticker}
-            </Link>
+          {POPULAR_TICKERS.map(t => (
+            <Button key={t} variant="outline" size="sm" onClick={() => router.push(`/aip/${t}`)}>
+              {t}
+            </Button>
           ))}
         </div>
       </div>

--- a/dashboard/src/app/api/aip/explain/[ticker]/route.ts
+++ b/dashboard/src/app/api/aip/explain/[ticker]/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from 'next/server';
+
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  'https://explainable-engine-516741092583.europe-west1.run.app';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ ticker: string }> }
+) {
+  const { ticker } = await params;
+
+  const res = await fetch(`${BACKEND_URL}/api/v1/aip/explain/${ticker}`, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  const data = await res.json();
+  return Response.json(data, { status: res.status });
+}

--- a/dashboard/src/app/api/aip/explain/[ticker]/route.ts
+++ b/dashboard/src/app/api/aip/explain/[ticker]/route.ts
@@ -1,19 +1,14 @@
 import type { NextRequest } from 'next/server';
-
-const BACKEND_URL =
-  process.env.BACKEND_URL ||
-  'https://explainable-engine-516741092583.europe-west1.run.app';
+const BACKEND_URL = process.env.BACKEND_URL || 'https://explainable-engine-516741092583.europe-west1.run.app';
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ ticker: string }> }
 ) {
   const { ticker } = await params;
-
   const res = await fetch(`${BACKEND_URL}/api/v1/aip/explain/${ticker}`, {
     headers: { 'Content-Type': 'application/json' },
   });
-
   const data = await res.json();
   return Response.json(data, { status: res.status });
 }

--- a/dashboard/src/app/api/aip/explain/market-mood/route.ts
+++ b/dashboard/src/app/api/aip/explain/market-mood/route.ts
@@ -1,0 +1,12 @@
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  'https://explainable-engine-516741092583.europe-west1.run.app';
+
+export async function GET() {
+  const res = await fetch(`${BACKEND_URL}/api/v1/aip/explain/market-mood`, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  const data = await res.json();
+  return Response.json(data, { status: res.status });
+}

--- a/dashboard/src/app/api/aip/explain/market-mood/route.ts
+++ b/dashboard/src/app/api/aip/explain/market-mood/route.ts
@@ -1,12 +1,10 @@
-const BACKEND_URL =
-  process.env.BACKEND_URL ||
-  'https://explainable-engine-516741092583.europe-west1.run.app';
+import { NextResponse } from 'next/server';
+const BACKEND_URL = process.env.BACKEND_URL || 'https://explainable-engine-516741092583.europe-west1.run.app';
 
 export async function GET() {
   const res = await fetch(`${BACKEND_URL}/api/v1/aip/explain/market-mood`, {
     headers: { 'Content-Type': 'application/json' },
   });
-
   const data = await res.json();
-  return Response.json(data, { status: res.status });
+  return NextResponse.json(data, { status: res.status });
 }

--- a/dashboard/src/components/aip/SentimentCard.tsx
+++ b/dashboard/src/components/aip/SentimentCard.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import type { AIPSentimentData } from '@/lib/api/types';
+
+function sentimentStyle(label: string) {
+  const lower = label.toLowerCase();
+  if (lower === 'bullish')
+    return {
+      text: 'text-emerald-600 dark:text-emerald-400',
+      bg: 'bg-emerald-500/10',
+      border: 'border-emerald-500/30',
+      badge: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+    };
+  if (lower === 'bearish')
+    return {
+      text: 'text-rose-600 dark:text-rose-400',
+      bg: 'bg-rose-500/10',
+      border: 'border-rose-500/30',
+      badge: 'bg-rose-500/15 text-rose-700 dark:text-rose-300',
+    };
+  return {
+    text: 'text-muted-foreground',
+    bg: 'bg-muted/50',
+    border: 'border-border',
+    badge: 'bg-muted text-muted-foreground',
+  };
+}
+
+function trendIndicator(trend: number) {
+  if (trend > 0.01) return { arrow: '\u2191', color: 'text-emerald-500' };
+  if (trend < -0.01) return { arrow: '\u2193', color: 'text-rose-500' };
+  return { arrow: '\u2192', color: 'text-muted-foreground' };
+}
+
+interface SentimentCardProps {
+  data: AIPSentimentData;
+}
+
+export function SentimentCard({ data }: SentimentCardProps) {
+  const style = sentimentStyle(data.sentiment_label);
+  const trend = trendIndicator(data.trend);
+
+  return (
+    <Link href={`/aip/${data.ticker}`} className="group block">
+      <Card
+        className={`h-full border ${style.border} transition-all duration-150 group-hover:shadow-sm group-hover:ring-1 group-hover:ring-primary/20`}
+      >
+        <CardContent className="space-y-3 p-4">
+          {/* Ticker + Label */}
+          <div className="flex items-center justify-between">
+            <span className="text-lg font-bold tracking-tight">
+              {data.ticker}
+            </span>
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs font-medium ${style.badge}`}
+            >
+              {data.sentiment_label}
+            </span>
+          </div>
+
+          {/* Sentiment value + trend */}
+          <div className="flex items-baseline gap-2">
+            <span className={`text-2xl font-bold tabular-nums ${style.text}`}>
+              {data.sentiment_7d >= 0 ? '+' : ''}
+              {data.sentiment_7d.toFixed(3)}
+            </span>
+            <span className={`text-sm font-medium ${trend.color}`}>
+              {trend.arrow}{' '}
+              {data.trend >= 0 ? '+' : ''}
+              {data.trend.toFixed(3)}
+            </span>
+          </div>
+
+          {/* Article count */}
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {data.article_count_7d} article{data.article_count_7d !== 1 ? 's' : ''} (7d)
+            </span>
+            <span>{(data.positive_ratio * 100).toFixed(0)}% positive</span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/dashboard/src/components/aip/SentimentCard.tsx
+++ b/dashboard/src/components/aip/SentimentCard.tsx
@@ -1,85 +1,44 @@
 'use client';
-
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
-import type { AIPSentimentData } from '@/lib/api/types';
-
-function sentimentStyle(label: string) {
-  const lower = label.toLowerCase();
-  if (lower === 'bullish')
-    return {
-      text: 'text-emerald-600 dark:text-emerald-400',
-      bg: 'bg-emerald-500/10',
-      border: 'border-emerald-500/30',
-      badge: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
-    };
-  if (lower === 'bearish')
-    return {
-      text: 'text-rose-600 dark:text-rose-400',
-      bg: 'bg-rose-500/10',
-      border: 'border-rose-500/30',
-      badge: 'bg-rose-500/15 text-rose-700 dark:text-rose-300',
-    };
-  return {
-    text: 'text-muted-foreground',
-    bg: 'bg-muted/50',
-    border: 'border-border',
-    badge: 'bg-muted text-muted-foreground',
-  };
-}
-
-function trendIndicator(trend: number) {
-  if (trend > 0.01) return { arrow: '\u2191', color: 'text-emerald-500' };
-  if (trend < -0.01) return { arrow: '\u2193', color: 'text-rose-500' };
-  return { arrow: '\u2192', color: 'text-muted-foreground' };
-}
 
 interface SentimentCardProps {
-  data: AIPSentimentData;
+  ticker: string;
+  sentiment: number;
+  label: string;
+  trend: number;
+  articleCount: number;
 }
 
-export function SentimentCard({ data }: SentimentCardProps) {
-  const style = sentimentStyle(data.sentiment_label);
-  const trend = trendIndicator(data.trend);
+function sentimentColor(label: string): string {
+  if (label.toLowerCase().includes('bullish')) return 'text-emerald-600';
+  if (label.toLowerCase().includes('bearish')) return 'text-rose-600';
+  return 'text-slate-500';
+}
 
+function trendArrow(trend: number): { icon: string; color: string } {
+  if (trend > 0.01) return { icon: '\u2191', color: 'text-emerald-500' };
+  if (trend < -0.01) return { icon: '\u2193', color: 'text-rose-500' };
+  return { icon: '\u2192', color: 'text-slate-400' };
+}
+
+export function SentimentCard({ ticker, sentiment, label, trend, articleCount }: SentimentCardProps) {
+  const t = trendArrow(trend);
   return (
-    <Link href={`/aip/${data.ticker}`} className="group block">
-      <Card
-        className={`h-full border ${style.border} transition-all duration-150 group-hover:shadow-sm group-hover:ring-1 group-hover:ring-primary/20`}
-      >
-        <CardContent className="space-y-3 p-4">
-          {/* Ticker + Label */}
+    <Link href={`/aip/${ticker}`}>
+      <Card className="cursor-pointer transition-shadow hover:shadow-md">
+        <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <span className="text-lg font-bold tracking-tight">
-              {data.ticker}
-            </span>
-            <span
-              className={`rounded-full px-2 py-0.5 text-xs font-medium ${style.badge}`}
-            >
-              {data.sentiment_label}
-            </span>
+            <span className="text-lg font-bold">{ticker}</span>
+            <span className={`text-xs font-medium ${sentimentColor(label)}`}>{label}</span>
           </div>
-
-          {/* Sentiment value + trend */}
-          <div className="flex items-baseline gap-2">
-            <span className={`text-2xl font-bold tabular-nums ${style.text}`}>
-              {data.sentiment_7d >= 0 ? '+' : ''}
-              {data.sentiment_7d.toFixed(3)}
+          <div className="mt-2 flex items-baseline gap-2">
+            <span className="text-2xl font-bold tabular-nums">
+              {sentiment >= 0 ? '+' : ''}{sentiment.toFixed(3)}
             </span>
-            <span className={`text-sm font-medium ${trend.color}`}>
-              {trend.arrow}{' '}
-              {data.trend >= 0 ? '+' : ''}
-              {data.trend.toFixed(3)}
-            </span>
+            <span className={`text-sm ${t.color}`}>{t.icon} {trend >= 0 ? '+' : ''}{trend.toFixed(3)}</span>
           </div>
-
-          {/* Article count */}
-          <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span>
-              {data.article_count_7d} article{data.article_count_7d !== 1 ? 's' : ''} (7d)
-            </span>
-            <span>{(data.positive_ratio * 100).toFixed(0)}% positive</span>
-          </div>
+          <div className="mt-1 text-xs text-muted-foreground">{articleCount} articles</div>
         </CardContent>
       </Card>
     </Link>

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Menu,
   X,
   ShieldCheck,
+  TrendingUp,
   User,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -33,6 +34,7 @@ const navigationGroups: NavGroup[] = [
     label: 'Main',
     items: [
       { name: 'Dashboard', href: '/', icon: Home },
+      { name: 'AIP Sentiment', href: '/aip', icon: TrendingUp },
       { name: 'Explanations', href: '/audit', icon: Layers },
     ],
   },

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -1,4 +1,6 @@
 import type {
+  AIPExplainResponse,
+  AIPMarketMoodResponse,
   AskRequest,
   AskResponse,
   ExplainRequest,
@@ -91,4 +93,11 @@ export const api = {
 
   stats: () =>
     fetchAPI<{ total_explanations: number; status: string }>('/stats'),
+
+  // AIP Sentiment
+  explainTicker: (ticker: string) =>
+    fetchAPI<AIPExplainResponse>(`/aip/explain/${ticker}`),
+
+  explainMarketMood: () =>
+    fetchAPI<AIPMarketMoodResponse>('/aip/explain/market-mood'),
 };

--- a/dashboard/src/lib/api/hooks.ts
+++ b/dashboard/src/lib/api/hooks.ts
@@ -100,3 +100,21 @@ export function useGenerateSummary(id: string | undefined) {
     mutationFn: (req: SummaryRequest) => api.generateSummary(id!, req),
   });
 }
+
+// AIP Sentiment hooks
+
+export function useAIPExplainTicker(ticker: string | undefined) {
+  return useQuery({
+    queryKey: ['aip-explain', ticker],
+    queryFn: () => api.explainTicker(ticker!),
+    enabled: !!ticker,
+  });
+}
+
+export function useAIPMarketMood() {
+  return useQuery({
+    queryKey: ['aip-market-mood'],
+    queryFn: () => api.explainMarketMood(),
+    refetchInterval: 60_000,
+  });
+}

--- a/dashboard/src/lib/api/types.ts
+++ b/dashboard/src/lib/api/types.ts
@@ -209,3 +209,31 @@ export interface SummaryResponse {
   audience: string;
   language: string;
 }
+
+// AIP (AI-Powered) Sentiment types
+
+export interface AIPSentimentData {
+  ticker: string;
+  sentiment_7d: number;
+  sentiment_30d: number;
+  trend: number;
+  article_count_7d: number;
+  positive_ratio: number;
+  sentiment_label: string;
+  sentiment_score_scaled: number;
+}
+
+export interface AIPExplainResponse {
+  explanation: ExplainResponse;
+  aip_data: AIPSentimentData;
+  ticker: string;
+}
+
+export interface AIPMarketMoodResponse {
+  explanation: ExplainResponse;
+  market_mood: {
+    overall_sentiment: number;
+    overall_trend: number;
+    total_articles: number;
+  };
+}

--- a/internal/aip/client.go
+++ b/internal/aip/client.go
@@ -1,0 +1,175 @@
+package aip
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://aip.aigenconsult.com"
+	defaultTimeout = 15 * time.Second
+	maxBulkTickers = 50
+)
+
+// AIPService defines the interface for interacting with the AIP sentiment API.
+// This abstraction allows tests to use mock implementations.
+type AIPService interface {
+	GetSentiment(ctx context.Context, ticker string) (*InstrumentSentiment, error)
+	GetBulkSentiment(ctx context.Context, tickers []string) ([]InstrumentSentiment, error)
+	GetMarketMood(ctx context.Context) (*MarketMood, error)
+	GetHeadlines(ctx context.Context, ticker string) ([]Headline, error)
+	GetHistory(ctx context.Context, ticker string) (*SentimentHistory, error)
+}
+
+// Client is the HTTP client for the AIP sentiment API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// Verify that Client implements AIPService at compile time.
+var _ AIPService = (*Client)(nil)
+
+// NewClient creates a new AIP API client with the given API key.
+func NewClient(apiKey string) *Client {
+	return &Client{
+		baseURL: defaultBaseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}
+}
+
+// GetSentiment fetches sentiment data for a single instrument.
+func (c *Client) GetSentiment(ctx context.Context, ticker string) (*InstrumentSentiment, error) {
+	url := fmt.Sprintf("%s/api/v1/external/sentiment/instruments/%s", c.baseURL, ticker)
+
+	var result InstrumentSentiment
+	if err := c.doGet(ctx, url, &result); err != nil {
+		return nil, fmt.Errorf("fetching sentiment for %s: %w", ticker, err)
+	}
+	return &result, nil
+}
+
+// GetBulkSentiment fetches sentiment data for multiple instruments (up to 50).
+func (c *Client) GetBulkSentiment(ctx context.Context, tickers []string) ([]InstrumentSentiment, error) {
+	if len(tickers) > maxBulkTickers {
+		return nil, fmt.Errorf("bulk request exceeds maximum of %d tickers (got %d)", maxBulkTickers, len(tickers))
+	}
+	if len(tickers) == 0 {
+		return nil, fmt.Errorf("tickers list must not be empty")
+	}
+
+	url := fmt.Sprintf("%s/api/v1/external/sentiment/instruments/bulk", c.baseURL)
+	body := BulkRequest{Tickers: tickers}
+
+	var result []InstrumentSentiment
+	if err := c.doPost(ctx, url, body, &result); err != nil {
+		return nil, fmt.Errorf("fetching bulk sentiment: %w", err)
+	}
+	return result, nil
+}
+
+// GetMarketMood fetches the overall market mood and per-sector breakdown.
+func (c *Client) GetMarketMood(ctx context.Context) (*MarketMood, error) {
+	url := fmt.Sprintf("%s/api/v1/external/sentiment/market-mood", c.baseURL)
+
+	var result MarketMood
+	if err := c.doGet(ctx, url, &result); err != nil {
+		return nil, fmt.Errorf("fetching market mood: %w", err)
+	}
+	return &result, nil
+}
+
+// GetHeadlines fetches news headlines for a single instrument.
+func (c *Client) GetHeadlines(ctx context.Context, ticker string) ([]Headline, error) {
+	url := fmt.Sprintf("%s/api/v1/external/sentiment/instruments/%s/headlines", c.baseURL, ticker)
+
+	var result []Headline
+	if err := c.doGet(ctx, url, &result); err != nil {
+		return nil, fmt.Errorf("fetching headlines for %s: %w", ticker, err)
+	}
+	return result, nil
+}
+
+// GetHistory fetches sentiment history for a single instrument.
+func (c *Client) GetHistory(ctx context.Context, ticker string) (*SentimentHistory, error) {
+	url := fmt.Sprintf("%s/api/v1/external/sentiment/instruments/%s/history", c.baseURL, ticker)
+
+	var result SentimentHistory
+	if err := c.doGet(ctx, url, &result); err != nil {
+		return nil, fmt.Errorf("fetching history for %s: %w", ticker, err)
+	}
+	return &result, nil
+}
+
+// doGet performs a GET request with the API key header and decodes the response.
+func (c *Client) doGet(ctx context.Context, url string, dest any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	return c.do(req, dest)
+}
+
+// doPost performs a POST request with a JSON body and decodes the response.
+func (c *Client) doPost(ctx context.Context, url string, body any, dest any) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return c.do(req, dest)
+}
+
+// do executes the HTTP request, sets common headers, and decodes the response.
+func (c *Client) do(req *http.Request, dest any) error {
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       string(respBody),
+		}
+	}
+
+	if err := json.Unmarshal(respBody, dest); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+// APIError represents an error response from the AIP API.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("AIP API error (status %d): %s", e.StatusCode, e.Body)
+}

--- a/internal/aip/transformer.go
+++ b/internal/aip/transformer.go
@@ -1,0 +1,119 @@
+package aip
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/blackms/ExplainableEngine/internal/models"
+)
+
+// TransformInstrumentSentiment converts AIP sentiment data into an ExplainRequest
+// that can be processed by the ExplainableEngine orchestrator.
+//
+// The transformation maps the AIP sentiment components into weighted factors:
+//   - sentiment_7d (35%): short-term sentiment, core signal
+//   - sentiment_30d (25%): longer-term sentiment, more stable baseline
+//   - trend (20%): direction of sentiment change
+//   - positive_ratio (10%): ratio of positive articles
+//   - news_score (10%): news-specific sentiment score
+//
+// Confidence is derived from article count and source availability.
+func TransformInstrumentSentiment(s *InstrumentSentiment) *models.ExplainRequest {
+	// Map sentiment_7d range [-1, 1] to a normalized value [0, 1].
+	normalizedScore := (s.Sentiment7D + 1) / 2 // -1->0, 0->0.5, 1->1
+
+	// Confidence based on article count: more articles = higher confidence, capped at 1.0.
+	articleConfidence := math.Min(float64(s.ArticleCount7D)/20.0, 1.0)
+
+	components := []models.Component{
+		{
+			Name:       "sentiment_7d",
+			Value:      s.Sentiment7D,
+			Weight:     0.35,
+			Confidence: articleConfidence,
+		},
+		{
+			Name:       "sentiment_30d",
+			Value:      s.Sentiment30D,
+			Weight:     0.25,
+			Confidence: math.Min(articleConfidence*1.5, 1.0), // 30d window is more stable
+		},
+		{
+			Name:       "trend",
+			Value:      s.Trend,
+			Weight:     0.20,
+			Confidence: articleConfidence,
+		},
+		{
+			Name:       "positive_ratio",
+			Value:      s.PositiveRatio,
+			Weight:     0.10,
+			Confidence: articleConfidence,
+		},
+		{
+			Name:       "news_score",
+			Value:      s.NewsSentiment.Score,
+			Weight:     0.10,
+			Confidence: boolToConfidence(s.NewsSentiment.HasRecentHeadlines),
+			Missing:    !s.NewsSentiment.HasRecentHeadlines && s.NewsSentiment.ArticleCount == 0,
+		},
+	}
+
+	return &models.ExplainRequest{
+		Target:     fmt.Sprintf("%s_sentiment", s.Ticker),
+		Value:      normalizedScore,
+		Components: components,
+		Metadata: map[string]string{
+			"source":          "aip",
+			"ticker":          s.Ticker,
+			"sentiment_label": s.SentimentLabel,
+			"last_updated":    s.LastUpdated,
+		},
+	}
+}
+
+// TransformMarketMood converts AIP market mood data into an ExplainRequest.
+// Each sector becomes a component whose weight is proportional to its article coverage.
+func TransformMarketMood(m *MarketMood) *models.ExplainRequest {
+	components := make([]models.Component, len(m.Sectors))
+
+	totalArticles := 0
+	for _, s := range m.Sectors {
+		totalArticles += s.ArticleCount
+	}
+
+	// Guard against division by zero when there are no articles.
+	if totalArticles == 0 {
+		totalArticles = 1
+	}
+
+	for i, sector := range m.Sectors {
+		weight := float64(sector.ArticleCount) / float64(totalArticles)
+		confidence := math.Min(float64(sector.ArticleCount)/100.0, 1.0)
+
+		components[i] = models.Component{
+			Name:       sector.Sector,
+			Value:      sector.AverageSentiment,
+			Weight:     weight,
+			Confidence: confidence,
+		}
+	}
+
+	return &models.ExplainRequest{
+		Target:     "market_mood",
+		Value:      m.OverallSentiment,
+		Components: components,
+		Metadata: map[string]string{
+			"source":         "aip",
+			"total_articles": fmt.Sprintf("%d", m.TotalArticles),
+		},
+	}
+}
+
+// boolToConfidence returns 1.0 for true and 0.0 for false.
+func boolToConfidence(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
+}

--- a/internal/aip/transformer_test.go
+++ b/internal/aip/transformer_test.go
@@ -1,0 +1,222 @@
+package aip
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTransformInstrumentSentiment(t *testing.T) {
+	s := &InstrumentSentiment{
+		Ticker:         "NVDA",
+		Sentiment7D:    0.158,
+		Sentiment30D:   0.270,
+		Trend:          -0.112,
+		ArticleCount7D: 6,
+		PositiveRatio:  0.33,
+		LastUpdated:    "2026-03-26T12:00:00Z",
+		SentimentLabel: "Neutral",
+		NewsSentiment: NewsSentiment{
+			Score:              0.158,
+			Label:              "Neutral",
+			ArticleCount:       6,
+			HasRecentHeadlines: true,
+		},
+		Sources: Sources{
+			News:    SourceDetail{Available: true},
+			Social:  SourceDetail{Available: false},
+			Analyst: SourceDetail{Available: false},
+		},
+	}
+
+	req := TransformInstrumentSentiment(s)
+
+	// Target should include the ticker.
+	if req.Target != "NVDA_sentiment" {
+		t.Errorf("target = %q, want %q", req.Target, "NVDA_sentiment")
+	}
+
+	// Value should be normalized: (0.158 + 1) / 2 = 0.579.
+	expectedValue := (0.158 + 1) / 2
+	if math.Abs(req.Value-expectedValue) > 1e-9 {
+		t.Errorf("value = %f, want %f", req.Value, expectedValue)
+	}
+
+	// Should have 5 components.
+	if len(req.Components) != 5 {
+		t.Fatalf("components count = %d, want 5", len(req.Components))
+	}
+
+	// Verify component names and weights.
+	expectedNames := []string{"sentiment_7d", "sentiment_30d", "trend", "positive_ratio", "news_score"}
+	expectedWeights := []float64{0.35, 0.25, 0.20, 0.10, 0.10}
+	for i, c := range req.Components {
+		if c.Name != expectedNames[i] {
+			t.Errorf("component[%d].Name = %q, want %q", i, c.Name, expectedNames[i])
+		}
+		if math.Abs(c.Weight-expectedWeights[i]) > 1e-9 {
+			t.Errorf("component[%d].Weight = %f, want %f", i, c.Weight, expectedWeights[i])
+		}
+	}
+
+	// Article confidence: 6 / 20 = 0.3.
+	expectedConf := 6.0 / 20.0
+	if math.Abs(req.Components[0].Confidence-expectedConf) > 1e-9 {
+		t.Errorf("sentiment_7d confidence = %f, want %f", req.Components[0].Confidence, expectedConf)
+	}
+
+	// 30d confidence: min(0.3 * 1.5, 1.0) = 0.45.
+	expectedConf30 := math.Min(expectedConf*1.5, 1.0)
+	if math.Abs(req.Components[1].Confidence-expectedConf30) > 1e-9 {
+		t.Errorf("sentiment_30d confidence = %f, want %f", req.Components[1].Confidence, expectedConf30)
+	}
+
+	// news_score should not be missing since HasRecentHeadlines is true.
+	if req.Components[4].Missing {
+		t.Error("news_score should not be marked missing when HasRecentHeadlines is true")
+	}
+
+	// Metadata should contain source info.
+	if req.Metadata["source"] != "aip" {
+		t.Errorf("metadata source = %q, want %q", req.Metadata["source"], "aip")
+	}
+	if req.Metadata["ticker"] != "NVDA" {
+		t.Errorf("metadata ticker = %q, want %q", req.Metadata["ticker"], "NVDA")
+	}
+}
+
+func TestTransformInstrumentSentiment_ZeroArticles(t *testing.T) {
+	s := &InstrumentSentiment{
+		Ticker:         "XYZ",
+		Sentiment7D:    0.0,
+		ArticleCount7D: 0,
+		NewsSentiment: NewsSentiment{
+			Score:              0,
+			ArticleCount:       0,
+			HasRecentHeadlines: false,
+		},
+	}
+
+	req := TransformInstrumentSentiment(s)
+
+	// With 0 articles, confidence should be 0.
+	if req.Components[0].Confidence != 0.0 {
+		t.Errorf("confidence with 0 articles = %f, want 0.0", req.Components[0].Confidence)
+	}
+
+	// news_score should be missing.
+	if !req.Components[4].Missing {
+		t.Error("news_score should be missing when no headlines and 0 articles")
+	}
+}
+
+func TestTransformInstrumentSentiment_HighArticleCount(t *testing.T) {
+	s := &InstrumentSentiment{
+		Ticker:         "AAPL",
+		Sentiment7D:    0.5,
+		ArticleCount7D: 100,
+		NewsSentiment: NewsSentiment{
+			Score:              0.5,
+			ArticleCount:       100,
+			HasRecentHeadlines: true,
+		},
+	}
+
+	req := TransformInstrumentSentiment(s)
+
+	// Confidence should be capped at 1.0 for high article counts.
+	if req.Components[0].Confidence != 1.0 {
+		t.Errorf("confidence with 100 articles = %f, want 1.0", req.Components[0].Confidence)
+	}
+}
+
+func TestTransformMarketMood(t *testing.T) {
+	m := &MarketMood{
+		OverallSentiment: 0.107,
+		OverallTrend:     0.043,
+		TotalArticles:    65043,
+		Sectors: []SectorSentiment{
+			{Sector: "Energy", AverageSentiment: 0.203, ArticleCount: 274, InstrumentCount: 22, Trend: 0.125},
+			{Sector: "Technology", AverageSentiment: 0.146, ArticleCount: 726, InstrumentCount: 30, Trend: 0.050},
+		},
+	}
+
+	req := TransformMarketMood(m)
+
+	if req.Target != "market_mood" {
+		t.Errorf("target = %q, want %q", req.Target, "market_mood")
+	}
+
+	if math.Abs(req.Value-0.107) > 1e-9 {
+		t.Errorf("value = %f, want %f", req.Value, 0.107)
+	}
+
+	if len(req.Components) != 2 {
+		t.Fatalf("components count = %d, want 2", len(req.Components))
+	}
+
+	// Weights should be proportional to article counts.
+	totalArticles := 274.0 + 726.0
+	expectedEnergyWeight := 274.0 / totalArticles
+	if math.Abs(req.Components[0].Weight-expectedEnergyWeight) > 1e-9 {
+		t.Errorf("Energy weight = %f, want %f", req.Components[0].Weight, expectedEnergyWeight)
+	}
+
+	expectedTechWeight := 726.0 / totalArticles
+	if math.Abs(req.Components[1].Weight-expectedTechWeight) > 1e-9 {
+		t.Errorf("Technology weight = %f, want %f", req.Components[1].Weight, expectedTechWeight)
+	}
+
+	// Sector names.
+	if req.Components[0].Name != "Energy" {
+		t.Errorf("component[0].Name = %q, want %q", req.Components[0].Name, "Energy")
+	}
+	if req.Components[1].Name != "Technology" {
+		t.Errorf("component[1].Name = %q, want %q", req.Components[1].Name, "Technology")
+	}
+
+	// Confidence: 274/100 = 2.74, capped at 1.0.
+	if req.Components[0].Confidence != 1.0 {
+		t.Errorf("Energy confidence = %f, want 1.0", req.Components[0].Confidence)
+	}
+}
+
+func TestTransformMarketMood_EmptySectors(t *testing.T) {
+	m := &MarketMood{
+		OverallSentiment: 0.0,
+		Sectors:          []SectorSentiment{},
+	}
+
+	req := TransformMarketMood(m)
+
+	if len(req.Components) != 0 {
+		t.Errorf("components count = %d, want 0", len(req.Components))
+	}
+}
+
+func TestTransformMarketMood_ZeroArticles(t *testing.T) {
+	m := &MarketMood{
+		OverallSentiment: 0.0,
+		Sectors: []SectorSentiment{
+			{Sector: "Energy", AverageSentiment: 0.1, ArticleCount: 0},
+		},
+	}
+
+	req := TransformMarketMood(m)
+
+	// With 0 total articles, weight should be 0/1 = 0 (guarded by totalArticles=1).
+	if req.Components[0].Weight != 0.0 {
+		t.Errorf("weight with 0 articles = %f, want 0.0", req.Components[0].Weight)
+	}
+	if req.Components[0].Confidence != 0.0 {
+		t.Errorf("confidence with 0 articles = %f, want 0.0", req.Components[0].Confidence)
+	}
+}
+
+func TestBoolToConfidence(t *testing.T) {
+	if boolToConfidence(true) != 1.0 {
+		t.Error("boolToConfidence(true) should be 1.0")
+	}
+	if boolToConfidence(false) != 0.0 {
+		t.Error("boolToConfidence(false) should be 0.0")
+	}
+}

--- a/internal/aip/types.go
+++ b/internal/aip/types.go
@@ -1,0 +1,101 @@
+package aip
+
+// InstrumentSentiment represents the AIP sentiment response for a single ticker.
+type InstrumentSentiment struct {
+	Ticker          string        `json:"ticker"`
+	Sentiment7D     float64       `json:"sentiment_7d"`
+	Sentiment30D    float64       `json:"sentiment_30d"`
+	Trend           float64       `json:"trend"`
+	ArticleCount7D  int           `json:"article_count_7d"`
+	PositiveRatio   float64       `json:"positive_ratio"`
+	LastUpdated     string        `json:"last_updated"`
+	SentimentLabel  string        `json:"sentiment_label"`
+	SentimentScaled int           `json:"sentiment_score_scaled"`
+	NewsSentiment   NewsSentiment `json:"news_sentiment"`
+	Sources         Sources       `json:"sources"`
+}
+
+// NewsSentiment contains the news-specific sentiment data.
+type NewsSentiment struct {
+	Score              float64 `json:"score"`
+	Label              string  `json:"label"`
+	ArticleCount       int     `json:"article_count"`
+	HasRecentHeadlines bool    `json:"has_recent_headlines"`
+}
+
+// Sources describes which data sources contributed to the sentiment.
+type Sources struct {
+	News    SourceDetail `json:"news"`
+	Social  SourceDetail `json:"social"`
+	Analyst SourceDetail `json:"analyst"`
+}
+
+// AvailableCount returns the number of available sources.
+func (s Sources) AvailableCount() int {
+	count := 0
+	if s.News.Available {
+		count++
+	}
+	if s.Social.Available {
+		count++
+	}
+	if s.Analyst.Available {
+		count++
+	}
+	return count
+}
+
+// TotalCount returns the total number of source types.
+func (s Sources) TotalCount() int {
+	return 3
+}
+
+// SourceDetail describes an individual data source.
+type SourceDetail struct {
+	Available bool   `json:"available"`
+	Provider  string `json:"provider,omitempty"`
+}
+
+// MarketMood represents the AIP market mood response.
+type MarketMood struct {
+	OverallSentiment float64           `json:"overall_sentiment"`
+	OverallTrend     float64           `json:"overall_trend"`
+	TotalArticles    int               `json:"total_articles"`
+	Sectors          []SectorSentiment `json:"sectors"`
+}
+
+// SectorSentiment represents sentiment data for a single market sector.
+type SectorSentiment struct {
+	Sector           string  `json:"sector"`
+	AverageSentiment float64 `json:"average_sentiment"`
+	ArticleCount     int     `json:"article_count"`
+	InstrumentCount  int     `json:"instrument_count"`
+	Trend            float64 `json:"trend"`
+}
+
+// Headline represents a single news headline from AIP.
+type Headline struct {
+	Title     string  `json:"title"`
+	Source    string  `json:"source"`
+	URL       string  `json:"url"`
+	Sentiment float64 `json:"sentiment"`
+	Published string  `json:"published"`
+}
+
+// SentimentHistory represents historical sentiment data from AIP.
+type SentimentHistory struct {
+	Ticker     string           `json:"ticker"`
+	DataPoints []HistoryPoint   `json:"data_points"`
+}
+
+// HistoryPoint is a single data point in the sentiment history.
+type HistoryPoint struct {
+	Date      string  `json:"date"`
+	Sentiment float64 `json:"sentiment"`
+	Articles  int     `json:"articles"`
+}
+
+// BulkRequest is the request body for the bulk sentiment endpoint.
+type BulkRequest struct {
+	Tickers []string `json:"tickers"`
+}

--- a/internal/api/aip.go
+++ b/internal/api/aip.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/blackms/ExplainableEngine/internal/aip"
+	"github.com/blackms/ExplainableEngine/internal/engine"
+	"github.com/blackms/ExplainableEngine/internal/storage"
+)
+
+// AIPHandler handles AIP-powered explanation endpoints.
+type AIPHandler struct {
+	aipClient    aip.AIPService
+	orchestrator engine.OrchestratorInterface
+	store        storage.ExplanationStore
+}
+
+// ExplainTicker fetches sentiment from AIP for a single ticker, transforms it
+// into an ExplainRequest, runs it through the orchestrator, and returns the result.
+//
+// GET /api/v1/aip/explain/{ticker}
+func (h *AIPHandler) ExplainTicker(w http.ResponseWriter, r *http.Request) {
+	ticker := r.PathValue("ticker")
+	if ticker == "" {
+		writeError(w, http.StatusBadRequest, "ticker is required")
+		return
+	}
+
+	sentiment, err := h.aipClient.GetSentiment(r.Context(), ticker)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch AIP sentiment: "+err.Error())
+		return
+	}
+
+	req := aip.TransformInstrumentSentiment(sentiment)
+
+	result, err := h.orchestrator.Explain(*req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "explanation failed: "+err.Error())
+		return
+	}
+
+	if err := h.store.Save(result); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save explanation: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"explanation": result,
+		"aip_data":    sentiment,
+		"ticker":      ticker,
+	})
+}
+
+// ExplainMarketMood fetches market mood from AIP, transforms sectors into components,
+// runs the explanation, and returns the result.
+//
+// GET /api/v1/aip/explain/market-mood
+func (h *AIPHandler) ExplainMarketMood(w http.ResponseWriter, r *http.Request) {
+	mood, err := h.aipClient.GetMarketMood(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch AIP market mood: "+err.Error())
+		return
+	}
+
+	req := aip.TransformMarketMood(mood)
+
+	result, err := h.orchestrator.Explain(*req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "explanation failed: "+err.Error())
+		return
+	}
+
+	if err := h.store.Save(result); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save explanation: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"explanation": result,
+		"aip_data":    mood,
+	})
+}
+
+// bulkExplainRequest is the JSON body for the bulk explain endpoint.
+type bulkExplainRequest struct {
+	Tickers []string `json:"tickers"`
+}
+
+// bulkExplainItem holds the result for a single ticker in a bulk request.
+type bulkExplainItem struct {
+	Ticker      string      `json:"ticker"`
+	Explanation any         `json:"explanation,omitempty"`
+	AIPData     any         `json:"aip_data,omitempty"`
+	Error       string      `json:"error,omitempty"`
+}
+
+// ExplainBulk fetches bulk sentiment from AIP and creates an explanation for each ticker.
+//
+// POST /api/v1/aip/explain/bulk
+func (h *AIPHandler) ExplainBulk(w http.ResponseWriter, r *http.Request) {
+	var body bulkExplainRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	if len(body.Tickers) == 0 {
+		writeError(w, http.StatusBadRequest, "tickers list must not be empty")
+		return
+	}
+	if len(body.Tickers) > 50 {
+		writeError(w, http.StatusBadRequest, "maximum 50 tickers per request")
+		return
+	}
+
+	sentiments, err := h.aipClient.GetBulkSentiment(r.Context(), body.Tickers)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch AIP bulk sentiment: "+err.Error())
+		return
+	}
+
+	results := make([]bulkExplainItem, len(sentiments))
+	for i, s := range sentiments {
+		sentiment := s // capture loop variable
+		req := aip.TransformInstrumentSentiment(&sentiment)
+
+		result, err := h.orchestrator.Explain(*req)
+		if err != nil {
+			results[i] = bulkExplainItem{
+				Ticker: sentiment.Ticker,
+				Error:  err.Error(),
+			}
+			continue
+		}
+
+		_ = h.store.Save(result) // best-effort save
+
+		results[i] = bulkExplainItem{
+			Ticker:      sentiment.Ticker,
+			Explanation: result,
+			AIPData:     &sentiment,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"results": results,
+		"count":   len(results),
+	})
+}

--- a/internal/api/api_aip_test.go
+++ b/internal/api/api_aip_test.go
@@ -1,0 +1,273 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blackms/ExplainableEngine/internal/aip"
+	"github.com/blackms/ExplainableEngine/internal/api"
+	"github.com/blackms/ExplainableEngine/internal/storage"
+)
+
+// mockAIPService implements aip.AIPService for testing.
+type mockAIPService struct {
+	sentiments  map[string]*aip.InstrumentSentiment
+	marketMood  *aip.MarketMood
+	errSentiment error
+	errMood      error
+}
+
+func (m *mockAIPService) GetSentiment(_ context.Context, ticker string) (*aip.InstrumentSentiment, error) {
+	if m.errSentiment != nil {
+		return nil, m.errSentiment
+	}
+	s, ok := m.sentiments[ticker]
+	if !ok {
+		return nil, fmt.Errorf("ticker %s not found", ticker)
+	}
+	return s, nil
+}
+
+func (m *mockAIPService) GetBulkSentiment(_ context.Context, tickers []string) ([]aip.InstrumentSentiment, error) {
+	if m.errSentiment != nil {
+		return nil, m.errSentiment
+	}
+	var results []aip.InstrumentSentiment
+	for _, t := range tickers {
+		s, ok := m.sentiments[t]
+		if !ok {
+			continue
+		}
+		results = append(results, *s)
+	}
+	return results, nil
+}
+
+func (m *mockAIPService) GetMarketMood(_ context.Context) (*aip.MarketMood, error) {
+	if m.errMood != nil {
+		return nil, m.errMood
+	}
+	return m.marketMood, nil
+}
+
+func (m *mockAIPService) GetHeadlines(_ context.Context, _ string) ([]aip.Headline, error) {
+	return nil, nil
+}
+
+func (m *mockAIPService) GetHistory(_ context.Context, _ string) (*aip.SentimentHistory, error) {
+	return nil, nil
+}
+
+func newAIPTestRouter(svc aip.AIPService) http.Handler {
+	store := storage.NewInMemoryStore()
+	orch := &mockOrchestrator{}
+	return api.NewRouter(store, orch, api.WithAIPClient(svc))
+}
+
+func sampleSentiment(ticker string) *aip.InstrumentSentiment {
+	return &aip.InstrumentSentiment{
+		Ticker:         ticker,
+		Sentiment7D:    0.158,
+		Sentiment30D:   0.270,
+		Trend:          -0.112,
+		ArticleCount7D: 6,
+		PositiveRatio:  0.33,
+		LastUpdated:    "2026-03-26T12:00:00Z",
+		SentimentLabel: "Neutral",
+		NewsSentiment: aip.NewsSentiment{
+			Score:              0.158,
+			Label:              "Neutral",
+			ArticleCount:       6,
+			HasRecentHeadlines: true,
+		},
+		Sources: aip.Sources{
+			News:    aip.SourceDetail{Available: true},
+			Social:  aip.SourceDetail{Available: false},
+			Analyst: aip.SourceDetail{Available: false},
+		},
+	}
+}
+
+func TestExplainTicker_Success(t *testing.T) {
+	svc := &mockAIPService{
+		sentiments: map[string]*aip.InstrumentSentiment{
+			"AAPL": sampleSentiment("AAPL"),
+		},
+	}
+	router := newAIPTestRouter(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/aip/explain/AAPL", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp["ticker"] != "AAPL" {
+		t.Errorf("ticker = %v, want AAPL", resp["ticker"])
+	}
+	if resp["explanation"] == nil {
+		t.Error("response should include explanation")
+	}
+	if resp["aip_data"] == nil {
+		t.Error("response should include aip_data")
+	}
+}
+
+func TestExplainTicker_AIPError(t *testing.T) {
+	svc := &mockAIPService{
+		sentiments:   map[string]*aip.InstrumentSentiment{},
+		errSentiment: fmt.Errorf("connection refused"),
+	}
+	router := newAIPTestRouter(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/aip/explain/AAPL", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+}
+
+func TestExplainMarketMood_Success(t *testing.T) {
+	svc := &mockAIPService{
+		sentiments: map[string]*aip.InstrumentSentiment{},
+		marketMood: &aip.MarketMood{
+			OverallSentiment: 0.107,
+			OverallTrend:     0.043,
+			TotalArticles:    65043,
+			Sectors: []aip.SectorSentiment{
+				{Sector: "Energy", AverageSentiment: 0.203, ArticleCount: 274, InstrumentCount: 22, Trend: 0.125},
+				{Sector: "Technology", AverageSentiment: 0.146, ArticleCount: 726, InstrumentCount: 30, Trend: 0.050},
+			},
+		},
+	}
+	router := newAIPTestRouter(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/aip/explain/market-mood", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["explanation"] == nil {
+		t.Error("response should include explanation")
+	}
+	if resp["aip_data"] == nil {
+		t.Error("response should include aip_data")
+	}
+}
+
+func TestExplainMarketMood_AIPError(t *testing.T) {
+	svc := &mockAIPService{
+		sentiments: map[string]*aip.InstrumentSentiment{},
+		errMood:    fmt.Errorf("timeout"),
+	}
+	router := newAIPTestRouter(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/aip/explain/market-mood", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+}
+
+func TestExplainBulk_Success(t *testing.T) {
+	svc := &mockAIPService{
+		sentiments: map[string]*aip.InstrumentSentiment{
+			"AAPL": sampleSentiment("AAPL"),
+			"MSFT": sampleSentiment("MSFT"),
+		},
+	}
+	router := newAIPTestRouter(svc)
+
+	body, _ := json.Marshal(map[string]any{"tickers": []string{"AAPL", "MSFT"}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/aip/explain/bulk", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	count, ok := resp["count"].(float64)
+	if !ok || count != 2 {
+		t.Errorf("count = %v, want 2", resp["count"])
+	}
+}
+
+func TestExplainBulk_EmptyTickers(t *testing.T) {
+	svc := &mockAIPService{sentiments: map[string]*aip.InstrumentSentiment{}}
+	router := newAIPTestRouter(svc)
+
+	body, _ := json.Marshal(map[string]any{"tickers": []string{}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/aip/explain/bulk", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestExplainBulk_TooManyTickers(t *testing.T) {
+	svc := &mockAIPService{sentiments: map[string]*aip.InstrumentSentiment{}}
+	router := newAIPTestRouter(svc)
+
+	tickers := make([]string, 51)
+	for i := range tickers {
+		tickers[i] = fmt.Sprintf("T%d", i)
+	}
+
+	body, _ := json.Marshal(map[string]any{"tickers": tickers})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/aip/explain/bulk", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAIPRoutesNotRegistered_WithoutClient(t *testing.T) {
+	// When no AIP client is provided, AIP routes should return 404.
+	store := storage.NewInMemoryStore()
+	orch := &mockOrchestrator{}
+	router := api.NewRouter(store, orch) // no WithAIPClient
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/aip/explain/AAPL", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (routes should not be registered without AIP client)", rec.Code, http.StatusNotFound)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/blackms/ExplainableEngine/internal/aip"
 	"github.com/blackms/ExplainableEngine/internal/engine"
 	"github.com/blackms/ExplainableEngine/internal/llm"
 	"github.com/blackms/ExplainableEngine/internal/storage"
@@ -46,12 +47,21 @@ func NewRouter(store storage.ExplanationStore, orch engine.OrchestratorInterface
 	mux.HandleFunc("POST /api/v1/explain/{id}/ask", llmHandler.AskQuestion)
 	mux.HandleFunc("POST /api/v1/explain/{id}/summary", llmHandler.GenerateSummary)
 
+	// AIP-powered endpoints (enabled when an AIP API key is configured).
+	if cfg.aipClient != nil {
+		aipHandler := &AIPHandler{aipClient: cfg.aipClient, orchestrator: orch, store: store}
+		mux.HandleFunc("GET /api/v1/aip/explain/market-mood", aipHandler.ExplainMarketMood)
+		mux.HandleFunc("GET /api/v1/aip/explain/{ticker}", aipHandler.ExplainTicker)
+		mux.HandleFunc("POST /api/v1/aip/explain/bulk", aipHandler.ExplainBulk)
+	}
+
 	return requestIDMiddleware(timingMiddleware(recoveryMiddleware(mux)))
 }
 
 // routerConfig holds optional configuration for the router.
 type routerConfig struct {
 	llmService llm.Service
+	aipClient  aip.AIPService
 }
 
 // RouterOption configures the router.
@@ -61,6 +71,13 @@ type RouterOption func(*routerConfig)
 func WithLLMService(svc llm.Service) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.llmService = svc
+	}
+}
+
+// WithAIPClient sets the AIP client for the router, enabling AIP-powered endpoints.
+func WithAIPClient(client aip.AIPService) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.aipClient = client
 	}
 }
 


### PR DESCRIPTION
## Summary

Full integration between AIP sentiment platform and ExplainableEngine.

### Backend (Go)
- AIP client with all 5 endpoints (sentiment, bulk, market mood, headlines, history)
- Transformer: maps sentiment components to EE ExplainRequest (sentiment_7d 35%, sentiment_30d 25%, trend 20%, positive_ratio 10%, news_score 10%)
- 3 new endpoints: `/api/v1/aip/explain/{ticker}`, `/api/v1/aip/explain/market-mood`, `/api/v1/aip/explain/bulk`
- Confidence derived from article count and source availability

### Dashboard
- AIP Sentiment page with ticker search + market mood card + quick explain chips
- Ticker detail page reusing BreakdownChart, DriverRanking, ConfidenceGauge
- SentimentCard component (color-coded bullish/neutral/bearish)
- BFF proxy routes for AIP endpoints
- Sidebar navigation updated

## How it works
1. User searches "NVDA" on AIP page
2. Backend fetches NVDA sentiment from AIP API
3. Transforms into ExplainRequest (5 weighted components)
4. Runs through EE orchestrator (breakdown, confidence, drivers, hash)
5. Returns combined response: EE explanation + AIP raw data
6. Dashboard renders full explainability view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AIP Sentiment Intelligence dashboard with market mood overview, sentiment trends, and article counts
  * New ticker-specific sentiment analysis pages featuring driver rankings, confidence metrics, and data quality indicators
  * Integrated sentiment explanation system with visual breakdown charts and historical sentiment data
  * Added AIP Sentiment navigation menu in sidebar for easy access to sentiment intelligence features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->